### PR TITLE
Fix typo on ttf-emojione

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation
 
 1. Install `emojione` from your package manager
   - Arch/Manjaro
-    `sudo yaourt -S tff-emojione --noconfirm`
+    `sudo yaourt -S ttf-emojione --noconfirm`
 
 1. Using your system package manager update/download the lastest version of cairo
   - Arch/Manjaro


### PR DESCRIPTION
The readme suggests you to download a `tff-emoji` package from `AUR`, which is actually called `ttf-emoji`.